### PR TITLE
Hephaestus-specific - Dev Branch

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.15)
 project(FoxgloveWebSocket CXX)
 
+include(FetchContent)
+FetchContent_Declare(
+    asio
+    GIT_REPOSITORY "https://github.com/chriskohlhoff/asio.git"
+    GIT_TAG "4730c543ba2b8f9396ef1964a25ccc26eb1aea64"
+)
+FetchContent_GetProperties(asio)
+
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
@@ -10,6 +18,7 @@ target_include_directories(foxglove_websocket
     SYSTEM
     ${nlohmann_json_INCLUDE_DIRS}
     ${websocketpp_INCLUDE_DIRS}
+    ${asio_SOURCE_DIR}/asio/include/
 )
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
@@ -23,4 +32,7 @@ endif()
 install(TARGETS foxglove_websocket)
 INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
          DESTINATION include)
+INSTALL (DIRECTORY ${asio_SOURCE_DIR}/asio/include/
+         DESTINATION include)         
+         
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -9,8 +9,8 @@ FetchContent_Declare(
 )
 FetchContent_GetProperties(asio)
 
-#find_package(nlohmann_json REQUIRED)
-#find_package(websocketpp REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(websocketpp REQUIRED)
 
 add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
 target_include_directories(foxglove_websocket

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -3,36 +3,35 @@ project(FoxgloveWebSocket CXX)
 
 include(FetchContent)
 FetchContent_Declare(
-    asio
-    GIT_REPOSITORY "https://github.com/chriskohlhoff/asio.git"
-    GIT_TAG "4730c543ba2b8f9396ef1964a25ccc26eb1aea64"
+  asio
+  GIT_REPOSITORY "https://github.com/chriskohlhoff/asio.git"
+  GIT_TAG "30a170c0e84a798a1752652439bd93f900062eda"
 )
 FetchContent_GetProperties(asio)
+if(NOT asio_POPULATED)
+  FetchContent_Populate(asio)
+endif()
+message(${asio_SOURCE_DIR})
 
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
 add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
-target_include_directories(foxglove_websocket
-    PUBLIC include
-    SYSTEM
-    ${nlohmann_json_INCLUDE_DIRS}
-    ${websocketpp_INCLUDE_DIRS}
-    ${asio_SOURCE_DIR}/asio/include/
+target_include_directories(
+  foxglove_websocket PUBLIC include ${asio_SOURCE_DIR}/asio/include/ SYSTEM ${nlohmann_json_INCLUDE_DIRS}
+                            ${websocketpp_INCLUDE_DIRS}
 )
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
-if (MSVC)
+if(MSVC)
   target_compile_options(foxglove_websocket PRIVATE /W4)
 else()
   target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Wold-style-cast -Wfloat-equal)
 endif()
 
 install(TARGETS foxglove_websocket)
-INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-         DESTINATION include)
-INSTALL (DIRECTORY ${asio_SOURCE_DIR}/asio/include/
-         DESTINATION include)         
-         
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
+install(DIRECTORY ${asio_SOURCE_DIR}/asio/include/ DESTINATION include)
+
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -3,85 +3,93 @@ project(FoxgloveWebSocket VERSION 1.4.0 LANGUAGES CXX)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
-
 include(FetchContent)
+
+# Fetch asio (header-only, C++11)
 FetchContent_Declare(
   asio
-  GIT_REPOSITORY "https://github.com/chriskohlhoff/asio.git"
-  GIT_TAG "30a170c0e84a798a1752652439bd93f900062eda"
+  GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+  GIT_TAG 30a170c0e84a798a1752652439bd93f900062eda
 )
-FetchContent_GetProperties(asio)
-if(NOT asio_POPULATED)
-  FetchContent_Populate(asio)
-endif()
-message(${asio_SOURCE_DIR})
+FetchContent_MakeAvailable(asio)
+add_library(asio_lib INTERFACE)
+target_include_directories(asio_lib INTERFACE
+  "${asio_SOURCE_DIR}/asio/include")
+target_compile_features(asio_lib INTERFACE cxx_std_11)
+add_library(asio::asio ALIAS asio_lib)
 
+# Fetch websocketpp (header-only, C++11)
+FetchContent_Declare(
+  websocketpp
+  GIT_REPOSITORY https://github.com/zaphoyd/websocketpp.git
+  GIT_TAG develop
+)
+FetchContent_MakeAvailable(websocketpp)
+
+add_library(websocketpp_lib INTERFACE)
+target_include_directories(websocketpp_lib INTERFACE
+  "${websocketpp_SOURCE_DIR}"
+)
+target_compile_features(websocketpp_lib INTERFACE cxx_std_11)
+add_library(websocketpp::websocketpp ALIAS websocketpp_lib)
+target_link_libraries(websocketpp_lib INTERFACE asio::asio)
+
+# Find JSON dependency
 find_package(nlohmann_json REQUIRED)
-find_package(websocketpp REQUIRED)
 
+# Main library (C++17, privately depends on asio_lib and websocketpp_lib)
 add_library(foxglove_websocket
   src/base64.cpp
   src/parameter.cpp
   src/serialization.cpp
   src/server_factory.cpp
 )
-
+set_target_properties(foxglove_websocket PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
 target_include_directories(foxglove_websocket
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include/>
-    PRIVATE
-        ${nlohmann_json_INCLUDE_DIRS}
-        ${websocketpp_INCLUDE_DIRS}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
-
 target_link_libraries(foxglove_websocket
-    PRIVATE
-        nlohmann_json::nlohmann_json
-        websocketpp::websocketpp
+  PRIVATE
+    websocketpp::websocketpp
+    nlohmann_json::nlohmann_json
 )
 
-set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
-
-if(MSVC)
-  target_compile_options(foxglove_websocket PRIVATE /W4)
-else()
-  target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Wold-style-cast -Wfloat-equal)
-endif()
-
-add_library(foxglove::foxglove_websocket ALIAS foxglove_websocket)
-
+# Export and install only the foxglove_websocket interface
 install(TARGETS foxglove_websocket
-        EXPORT foxglove_websocket-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(DIRECTORY ${asio_SOURCE_DIR}/asio/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)
+  EXPORT foxglove_websocket-targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 install(EXPORT foxglove_websocket-targets
-        FILE foxglove_websocket-targets.cmake
-        NAMESPACE foxglove::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket)
+  FILE foxglove_websocket-targets.cmake
+  NAMESPACE foxglove::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
+)
 
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/foxglove_websocket-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
+  "${CMAKE_CURRENT_SOURCE_DIR}/foxglove_websocket-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
 )
 
 write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
 )
-
-install(FILES 
-    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config-version.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
-)
-

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -7,6 +7,8 @@ include(GNUInstallDirs)
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
+add_definitions(-DASIO_STANDALONE)
+
 add_library(foxglove_websocket
   src/base64.cpp
   src/parameter.cpp
@@ -29,7 +31,7 @@ target_link_libraries(foxglove_websocket
         websocketpp::websocketpp
 )
 
-set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
   target_compile_options(foxglove_websocket PRIVATE /W4)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,17 +1,34 @@
 cmake_minimum_required(VERSION 3.15)
-project(FoxgloveWebSocket CXX)
+project(FoxgloveWebSocket VERSION 1.4.0 LANGUAGES CXX)
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
-add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
-target_include_directories(foxglove_websocket
-    PUBLIC include
-    SYSTEM
-    ${nlohmann_json_INCLUDE_DIRS}
-    ${websocketpp_INCLUDE_DIRS}
+add_library(foxglove_websocket
+  src/base64.cpp
+  src/parameter.cpp
+  src/serialization.cpp
+  src/server_factory.cpp
 )
-target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
+
+target_include_directories(foxglove_websocket
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        ${nlohmann_json_INCLUDE_DIRS}
+        ${websocketpp_INCLUDE_DIRS}
+)
+
+target_link_libraries(foxglove_websocket
+    PRIVATE
+        nlohmann_json::nlohmann_json
+        websocketpp::websocketpp
+)
+
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
@@ -20,7 +37,37 @@ else()
   target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Wold-style-cast -Wfloat-equal)
 endif()
 
-install(TARGETS foxglove_websocket)
-INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-         DESTINATION include)
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)
+add_library(foxglove::foxglove_websocket ALIAS foxglove_websocket)
+
+install(TARGETS foxglove_websocket
+        EXPORT foxglove_websocket-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT foxglove_websocket-targets
+        FILE foxglove_websocket-targets.cmake
+        NAMESPACE foxglove::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/foxglove_websocket-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/foxglove_websocket
+)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/foxglove_websocket/)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -51,6 +51,8 @@ set_target_properties(foxglove_websocket PROPERTIES
 target_include_directories(foxglove_websocket
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${websocketpp_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include>
     $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(foxglove_websocket
@@ -59,14 +61,20 @@ target_link_libraries(foxglove_websocket
     nlohmann_json::nlohmann_json
 )
 
-# Export and install only the foxglove_websocket interface
 install(TARGETS foxglove_websocket
   EXPORT foxglove_websocket-targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(DIRECTORY ${websocketpp_SOURCE_DIR}/websocketpp
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(DIRECTORY ${asio_SOURCE_DIR}/asio/include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -87,6 +95,7 @@ write_basic_package_version_file(
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion
 )
+
 install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/foxglove_websocket-config.cmake"

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -9,8 +9,8 @@ FetchContent_Declare(
 )
 FetchContent_GetProperties(asio)
 
-find_package(nlohmann_json REQUIRED)
-find_package(websocketpp REQUIRED)
+#find_package(nlohmann_json REQUIRED)
+#find_package(websocketpp REQUIRED)
 
 add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
 target_include_directories(foxglove_websocket

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -14,7 +14,13 @@ class FoxgloveWebSocketConan(ConanFile):
 
     settings = ("os", "compiler", "build_type", "arch")
     generators = "CMakeDeps"
-    exports_sources = "CMakeLists.txt", "LICENSE", "src/*", "include/*"
+    exports_sources = (
+        "CMakeLists.txt",
+        "foxglove_websocket-config.cmake.in",  # <--- Add this line
+        "LICENSE",
+        "src/*",
+        "include/*",
+    )
     options = {"asio": ["standalone", "boost"]}
     default_options = {"asio": "standalone"}
 

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -16,7 +16,7 @@ class FoxgloveWebSocketConan(ConanFile):
     generators = "CMakeDeps"
     exports_sources = (
         "CMakeLists.txt",
-        "foxglove_websocket-config.cmake.in",  # <--- Add this line
+        "foxglove_websocket-config.cmake.in",
         "LICENSE",
         "src/*",
         "include/*",

--- a/cpp/foxglove-websocket/foxglove_websocket-config.cmake.in
+++ b/cpp/foxglove-websocket/foxglove_websocket-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(nlohmann_json REQUIRED)
+find_dependency(websocketpp REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/foxglove_websocket-targets.cmake")

--- a/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <optional>
 #include <stdint.h>
@@ -143,18 +144,19 @@ struct Service : ServiceWithoutId {
 struct ServiceResponse {
   ServiceId serviceId;
   uint32_t callId;
+  uint32_t timeoutMs = 0;  // 0 = client does not set a specific timeout
   std::string encoding;
   std::vector<uint8_t> data;
 
   size_t size() const {
-    return 4 + 4 + 4 + encoding.size() + data.size();
+    return 4 + 4 + 4 + 4 + encoding.size() + data.size();
   }
   void read(const uint8_t* payload, size_t payloadSize);
   void write(uint8_t* payload) const;
 
   bool operator==(const ServiceResponse& other) const {
     return serviceId == other.serviceId && callId == other.callId && encoding == other.encoding &&
-           data == other.data;
+           data == other.data && other.timeoutMs == timeoutMs;
   }
 };
 

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_factory.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_factory.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <websocketpp/common/connection_hdl.hpp>
 
 #include <memory>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -51,6 +51,7 @@ struct ServerOptions {
   std::string certfile = "";
   std::string keyfile = "";
   std::string sessionId;
+  uint8_t numWorkerThreads = 1;
   bool useCompression = false;
   std::vector<std::regex> clientTopicWhitelistPatterns;
 };

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -51,7 +51,7 @@ struct ServerOptions {
   std::string certfile = "";
   std::string keyfile = "";
   std::string sessionId;
-  uint8_t numWorkerThreads = 1;
+  size_t numWorkerThreads = 1;
   bool useCompression = false;
   std::vector<std::regex> clientTopicWhitelistPatterns;
 };

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <nlohmann/json.hpp>
 #include <websocketpp/client.hpp>
 #include <websocketpp/common/memory.hpp>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_logging.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_logging.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <websocketpp/common/asio.hpp>
 #include <websocketpp/logger/levels.hpp>
 

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_notls.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_notls.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/extensions/permessage_deflate/enabled.hpp>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_notls.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_notls.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define ASIO_STANDALONE
+
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/extensions/permessage_deflate/enabled.hpp>
 #include <websocketpp/server.hpp>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -266,7 +266,7 @@ inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,
   _server.set_listen_backlog(128);
 
   // Callback queue for handling client requests.
-  _handlerCallbackQueue = std::make_unique<CallbackQueue>(_logger, /*numThreads=*/1ul);
+  _handlerCallbackQueue = std::make_unique<CallbackQueue>(_logger, /*numThreads=*/10ul);
 }
 
 template <typename ServerConfiguration>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -266,7 +266,7 @@ inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,
   _server.set_listen_backlog(128);
 
   // Callback queue for handling client requests.
-  _handlerCallbackQueue = std::make_unique<CallbackQueue>(_logger, /*numThreads=*/10ul);
+  _handlerCallbackQueue = std::make_unique<CallbackQueue>(_logger, options.numWorkerThreads);
 }
 
 template <typename ServerConfiguration>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <nlohmann/json.hpp>
 #include <websocketpp/config/asio.hpp>
 #include <websocketpp/server.hpp>

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_tls.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_tls.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <websocketpp/config/asio.hpp>
 #include <websocketpp/extensions/permessage_deflate/enabled.hpp>
 

--- a/cpp/foxglove-websocket/src/serialization.cpp
+++ b/cpp/foxglove-websocket/src/serialization.cpp
@@ -187,6 +187,8 @@ void ServiceResponse::read(const uint8_t* payload, size_t payloadSize) {
   offset += 4;
   this->callId = ReadUint32LE(payload + offset);
   offset += 4;
+  this->timeoutMs = ReadUint32LE(payload + offset);
+  offset += 4;
   const size_t encondingLength = static_cast<size_t>(ReadUint32LE(payload + offset));
   offset += 4;
   this->encoding = std::string(reinterpret_cast<const char*>(payload + offset), encondingLength);
@@ -201,6 +203,8 @@ void ServiceResponse::write(uint8_t* payload) const {
   foxglove::WriteUint32LE(payload + offset, this->serviceId);
   offset += 4;
   foxglove::WriteUint32LE(payload + offset, this->callId);
+  offset += 4;
+  foxglove::WriteUint32LE(payload + offset, this->timeoutMs);
   offset += 4;
   foxglove::WriteUint32LE(payload + offset, static_cast<uint32_t>(this->encoding.size()));
   offset += 4;

--- a/cpp/foxglove-websocket/src/serialization.cpp
+++ b/cpp/foxglove-websocket/src/serialization.cpp
@@ -1,5 +1,6 @@
+#include "foxglove/websocket/serialization.hpp"
+
 #include <foxglove/websocket/base64.hpp>
-#include <foxglove/websocket/serialization.hpp>
 
 namespace foxglove {
 

--- a/cpp/foxglove-websocket/src/server_factory.cpp
+++ b/cpp/foxglove-websocket/src/server_factory.cpp
@@ -1,3 +1,7 @@
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+
 #include <foxglove/websocket/server_factory.hpp>
 #include <foxglove/websocket/websocket_notls.hpp>
 #include <foxglove/websocket/websocket_server.hpp>


### PR DESCRIPTION
Our development branch currently contains the following changes:
 - Enable discovery of the foxglove websocket package with find_package
    - Why? - Duh
 - Expose the number of worker config for the websocket server callback queue.
    - Why? - This is essential, because the default value (1) blocks all client-side traffic during a service call. I.e. if a service call takes a couple hundred milliseconds, no client-side traffic will reach the other side of the bridge.
 These two are a bit hacky and we should clean this up, eventually, sometime:
 - Pull in ASIO headers and make sure we build / use ASIO standalone
    - Why? - So we don't have any boost in our system
 - Pull in the develop branch of websocketpp directly as source
    - Why? - The latest-and-ancient-greatest websocketpp release does not compile with cpp++20, the development branch does. https://github.com/zaphoyd/websocketpp/issues/991
    
Note: with this increasing diff, we might want to consider just absorbing the ws-protocol cpp impl.